### PR TITLE
Batches update/re-design

### DIFF
--- a/flash-loan-vault/src/contract.rs
+++ b/flash-loan-vault/src/contract.rs
@@ -77,6 +77,7 @@ impl VaultContractTrait for VaultContract {
         batch
     }
 
+    // Batches returns an integer `current_n`. Batches are stored with key `BatchKey(Address, current_n)`, so having `current_n` and iterating up to it (0..n) will help to gather all of the user's batches (you'll still need to filter for batches that have been completely withdrawn, thus deleted).
     fn batches(e: Env, id: Address) -> Vec<i128> {
         get_user_batches(&e, id)
     }

--- a/flash-loan-vault/src/contract.rs
+++ b/flash-loan-vault/src/contract.rs
@@ -15,13 +15,13 @@ pub trait VaultContractTrait {
         flash_loan_bytes: BytesN<32>,
     );
 
-    fn deposit(e: Env, from: Address, amount: i128) -> u64;
+    fn deposit(e: Env, from: Address, amount: i128) -> i128;
 
-    fn fee_withd(e: Env, to: Address, batch_ts: u64, shares: i128);
+    fn fee_withd(e: Env, to: Address, batch_ts: i128, shares: i128);
 
-    fn get_shares(e: Env, id: Address, batch_ts: u64) -> BatchObj;
+    fn get_shares(e: Env, id: Address, batch_ts: i128) -> Option<BatchObj>;
 
-    fn batches(e: Env, id: Address) -> Vec<u64>;
+    fn batches(e: Env, id: Address) -> Vec<i128>;
 
     fn withdraw(e: Env, to: Address) -> i128;
 }
@@ -49,7 +49,7 @@ impl VaultContractTrait for VaultContract {
         put_token_id(&e, token_id);
     }
 
-    fn deposit(e: Env, from: Address, amount: i128) -> u64 {
+    fn deposit(e: Env, from: Address, amount: i128) -> i128 {
         transfer_in_vault(&e, &from, &amount);
 
         let contract_id = get_token_id(&e);
@@ -69,24 +69,24 @@ impl VaultContractTrait for VaultContract {
         mint_shares(&e, from, shares, amount)
     }
 
-    fn get_shares(e: Env, id: Address, batch_ts: u64) -> BatchObj {
-        let key = DataKey::Batch(BatchKey(id, batch_ts));
+    fn get_shares(e: Env, id: Address, batch_n: i128) -> Option<BatchObj> {
+        let key = DataKey::Batch(BatchKey(id, batch_n));
 
-        let batch: BatchObj = e.storage().get(&key).unwrap().unwrap();
+        let batch: Option<BatchObj> = e.storage().get(&key).unwrap_or(Ok(None)).unwrap();
 
         batch
     }
 
-    fn batches(e: Env, id: Address) -> Vec<u64> {
+    fn batches(e: Env, id: Address) -> Vec<i128> {
         get_user_batches(&e, id)
     }
 
-    fn fee_withd(e: Env, to: Address, batch_ts: u64, shares: i128) {
+    fn fee_withd(e: Env, to: Address, batch_n: i128, shares: i128) {
         let tot_supply = get_tot_supply(&e);
         let tot_bal = get_token_balance(&e);
         let batch: BatchObj = e
             .storage()
-            .get(&DataKey::Batch(BatchKey(to.clone(), batch_ts)))
+            .get(&DataKey::Batch(BatchKey(to.clone(), batch_n)))
             .unwrap()
             .unwrap();
         let deposit = batch.deposit;
@@ -102,7 +102,7 @@ impl VaultContractTrait for VaultContract {
         let fee_amount = ((tot_bal * shares) / tot_supply) - new_deposit;
         if fee_amount >= 0 {
             transfer(&e, &to, fee_amount);
-            burn_shares(&e, to.clone(), shares, batch_ts);
+            burn_shares(&e, to.clone(), shares, batch_n);
             let new_tot_supply = get_tot_supply(&e);
             let new_tot_bal = get_token_balance(&e);
 
@@ -125,9 +125,9 @@ impl VaultContractTrait for VaultContract {
         let mut temp_balance: i128 = get_token_balance(&e);
 
         for batch_el in batches.iter() {
-            let batch_ts = batch_el.unwrap_or_else(|_| panic!("no ts in batch"));
+            let batch_n = batch_el.unwrap_or_else(|_| panic!("no ts in batch"));
 
-            let key = DataKey::Batch(BatchKey(to.clone(), batch_ts));
+            let key = DataKey::Batch(BatchKey(to.clone(), batch_n));
             let batch: BatchObj = e
                 .storage()
                 .get(&key.clone())
@@ -146,7 +146,7 @@ impl VaultContractTrait for VaultContract {
             temp_balance -= fee_amount;
             temp_supply -= curr_s;
 
-            burn_shares(&e, to.clone(), curr_s, batch_ts);
+            burn_shares(&e, to.clone(), curr_s, batch_n);
 
             if temp_balance != new_deposit {
                 temp_supply += (new_deposit * temp_supply) / (temp_balance - new_deposit);

--- a/flash-loan-vault/src/storage.rs
+++ b/flash-loan-vault/src/storage.rs
@@ -87,7 +87,6 @@ pub fn mint_shares(e: &Env, to: Address, shares: i128, deposit: i128) -> i128 {
     let tot_supply = get_tot_supply(e);
     put_tot_supply(e, tot_supply + shares);
 
-    //    let ts = e.ledger().timestamp();
     let n = get_increment(e, to.clone());
     let key = DataKey::Batch(BatchKey(to.clone(), n));
 
@@ -97,7 +96,6 @@ pub fn mint_shares(e: &Env, to: Address, shares: i128, deposit: i128) -> i128 {
         curr_s: shares,
     };
 
-    //    add_user_batch(e, to, ts);
     put_increment(e, to, n + 1);
     e.storage().set(&key, &val);
 
@@ -114,24 +112,6 @@ pub fn get_user_batches(e: &Env, id: Address) -> Vec<i128> {
     batches
 }
 
-/*pub fn add_user_batch(e: &Env, id: Address, batch_ts: u64) {
-    let mut batches = get_user_batches(e, id.clone());
-    batches.push_front(batch_ts);
-
-    let key = DataKey::Batches(id);
-    e.storage().set(&key, &batches);
-}
-
-pub fn remove_user_batch(e: &Env, id: Address, batch_ts: u64) {
-    let mut batches = get_user_batches(e, id.clone());
-    let batch_idx = batches.iter().position(|x| x.unwrap() == batch_ts).unwrap();
-
-    batches.remove(batch_idx as u32);
-
-    let key = DataKey::Batches(id);
-    e.storage().set(&key, &batches);
-}*/
-
 pub fn burn_shares(e: &Env, to: Address, shares: i128, batch_n: i128) {
     let tot_supply = get_tot_supply(e);
     let key = DataKey::Batch(BatchKey(to.clone(), batch_n));
@@ -142,7 +122,6 @@ pub fn burn_shares(e: &Env, to: Address, shares: i128, batch_n: i128) {
 
     if batch.curr_s == 0 {
         e.storage().remove(&key); // if there are 0 shares remove the batch
-                                  //        remove_user_batch(e, to, batch_n);
     } else {
         e.storage().set(&key, &batch);
     }

--- a/flash-loan-vault/src/types.rs
+++ b/flash-loan-vault/src/types.rs
@@ -10,7 +10,6 @@ pub enum DataKey {
     FlashLoanB,
     InitialDep(Address),
     Batch(BatchKey),
-    Batches(Address),
     Increment(Address),
 }
 

--- a/flash-loan-vault/src/types.rs
+++ b/flash-loan-vault/src/types.rs
@@ -11,6 +11,7 @@ pub enum DataKey {
     InitialDep(Address),
     Batch(BatchKey),
     Batches(Address),
+    Increment(Address),
 }
 
 #[contracterror]
@@ -22,7 +23,7 @@ pub enum Error {
 
 #[derive(Clone)]
 #[contracttype]
-pub struct BatchKey(pub Address, pub u64);
+pub struct BatchKey(pub Address, pub i128);
 
 #[derive(Clone)]
 #[contracttype]

--- a/flash-loan-vault/tests/test.rs
+++ b/flash-loan-vault/tests/test.rs
@@ -27,14 +27,6 @@ fn test() {
     let e: Env = Default::default();
     let admin1 = Address::random(&e);
 
-    e.ledger().set(LedgerInfo {
-        timestamp: 1666359075,
-        protocol_version: 1,
-        sequence_number: 10,
-        network_id: Default::default(),
-        base_reserve: 10,
-    });
-
     let user1 = Address::random(&e);
     let user2 = Address::random(&e);
 
@@ -61,82 +53,52 @@ fn test() {
 
     assert_eq!(usdc_token.balance(&user1), 500);
 
-    let _batch = vault_client.get_shares(&user1, &1666359075);
-
-    e.ledger().set(LedgerInfo {
-        timestamp: 1667369075,
-        protocol_version: 1,
-        sequence_number: 10,
-        network_id: Default::default(),
-        base_reserve: 10,
-    });
-
-    vault_client.fee_withd(&user1, &1666359075, &500);
+    vault_client.fee_withd(&user1, &0, &500);
 
     assert_eq!(usdc_token.balance(&user1), 500);
 
-    let _batch = vault_client.get_shares(&user1, &1667369075);
-
-    e.ledger().set(LedgerInfo {
-        timestamp: 1767369075,
-        protocol_version: 1,
-        sequence_number: 10,
-        network_id: Default::default(),
-        base_reserve: 10,
-    });
+    let _batch = vault_client.get_shares(&user1, &0);
 
     vault_client.deposit(&user2, &1000);
 
     assert_eq!(usdc_token.balance(&user2), 0);
 
-    let _batch = vault_client.get_shares(&user2, &1767369075);
+    let _batch = vault_client.get_shares(&user2, &0);
 
-    e.ledger().set(LedgerInfo {
-        timestamp: 1867369075,
-        protocol_version: 1,
-        sequence_number: 10,
-        network_id: Default::default(),
-        base_reserve: 10,
-    });
-
-    vault_client.fee_withd(&user2, &1767369075, &1000);
+    vault_client.fee_withd(&user2, &0, &1000);
 
     // fees arrive
     usdc_token.mint(&admin1, &vault_id, &(100));
 
-    e.ledger().set(LedgerInfo {
-        timestamp: 1967369075,
-        protocol_version: 1,
-        sequence_number: 10,
-        network_id: Default::default(),
-        base_reserve: 10,
-    });
+    vault_client.fee_withd(&user2, &1, &500);
 
-    vault_client.fee_withd(&user2, &1867369075, &500);
-
-    let _batch = vault_client.get_shares(&user2, &1867369075);
+    let _batch = vault_client.get_shares(&user2, &1);
 
     extern crate std;
     for batch_el in vault_client.batches(&user1).iter() {
         let el_u = batch_el.unwrap();
-        std::println!(
-            "\n\n user 1 batch {:?} is {:?} {:?} {:?} \n",
-            el_u,
-            vault_client.get_shares(&user1, &el_u).curr_s,
-            vault_client.get_shares(&user1, &el_u).init_s,
-            vault_client.get_shares(&user1, &el_u).deposit,
-        );
+        if let Some(batch) = vault_client.get_shares(&user1, &el_u) {
+            std::println!(
+                "\n\n user 1 batch {:?} is {:?} {:?} {:?} \n",
+                el_u,
+                batch.curr_s,
+                batch.init_s,
+                batch.deposit,
+            );
+        }
     }
 
     for batch_el in vault_client.batches(&user2).iter() {
         let el_u = batch_el.unwrap();
-        std::println!(
-            "\n\n user 2 batch {:?} is {:?} {:?} {:?} \n",
-            el_u,
-            vault_client.get_shares(&user2, &el_u).curr_s,
-            vault_client.get_shares(&user2, &el_u).init_s,
-            vault_client.get_shares(&user2, &el_u).deposit,
-        );
+        if let Some(batch) = vault_client.get_shares(&user2, &el_u) {
+            std::println!(
+                "\n\n user 2 batch {:?} is {:?} {:?} {:?} \n",
+                el_u,
+                batch.curr_s,
+                batch.init_s,
+                batch.deposit,
+            );
+        }
     }
 
     std::println!(
@@ -165,24 +127,28 @@ fn test() {
 
     for batch_el in vault_client.batches(&user1).iter() {
         let el_u = batch_el.unwrap();
-        std::println!(
-            "\n\n user 1 batch {:?} is {:?} {:?} {:?} \n",
-            el_u,
-            vault_client.get_shares(&user1, &el_u).curr_s,
-            vault_client.get_shares(&user1, &el_u).init_s,
-            vault_client.get_shares(&user1, &el_u).deposit,
-        );
+        if let Some(batch) = vault_client.get_shares(&user1, &el_u) {
+            std::println!(
+                "\n\n user 1 batch {:?} is {:?} {:?} {:?} \n",
+                el_u,
+                batch.curr_s,
+                batch.init_s,
+                batch.deposit,
+            );
+        }
     }
 
     for batch_el in vault_client.batches(&user2).iter() {
         let el_u = batch_el.unwrap();
-        std::println!(
-            "\n\n user 2 batch {:?} is {:?} {:?} {:?} \n",
-            el_u,
-            vault_client.get_shares(&user2, &el_u).curr_s,
-            vault_client.get_shares(&user2, &el_u).init_s,
-            vault_client.get_shares(&user2, &el_u).deposit,
-        );
+        if let Some(batch) = vault_client.get_shares(&user2, &el_u) {
+            std::println!(
+                "\n\n user 2 batch {:?} is {:?} {:?} {:?} \n",
+                el_u,
+                batch.curr_s,
+                batch.init_s,
+                batch.deposit,
+            );
+        }
     }
 
     let _logs = e.logger().all();

--- a/proxy/src/contract.rs
+++ b/proxy/src/contract.rs
@@ -39,7 +39,7 @@ pub trait LPTrait {
         env: Env,
         lender: Address,
         token_contract_id: BytesN<32>,
-        batch_ts: u64,
+        batch_ts: i128,
         amount: i128,
     ) -> Result<(), Error>;
 }
@@ -105,10 +105,10 @@ impl LPTrait for ProxyLP {
         env: Env,
         lender: Address,
         token_contract_id: BytesN<32>,
-        batch_ts: u64,
+        batch_n: i128,
         shares: i128,
     ) -> Result<(), Error> {
-        vault_withdraw_fees(&env, lender, token_contract_id, batch_ts, shares)?;
+        vault_withdraw_fees(&env, lender, token_contract_id, batch_n, shares)?;
         Ok(())
     }
 }

--- a/proxy/src/storage.rs
+++ b/proxy/src/storage.rs
@@ -78,11 +78,11 @@ pub fn vault_withdraw_fees(
     env: &Env,
     provider: Address,
     token_contract_id: BytesN<32>,
-    batch_ts: u64,
+    batch_n: i128,
     shares: i128,
 ) -> Result<(), Error> {
     let vault_client = vault::Client::new(env, &get_vault(env, token_contract_id)?);
-    vault_client.fee_withd(&provider, &batch_ts, &shares);
+    vault_client.fee_withd(&provider, &batch_n, &shares);
     Ok(())
 }
 

--- a/proxy/tests/test.rs
+++ b/proxy/tests/test.rs
@@ -88,7 +88,6 @@ fn workflow() {
     proxy_client.set_fl(&protocol, &token_id, &flash_loan_contract_id);
 
     usdc_token.mint(&token_admin, &lp, &1000000);
-
     proxy_client.deposit(&lp, &token_id, &1000000);
 
     assert_eq!(usdc_token.balance(&vault_id), 0);


### PR DESCRIPTION
This update is needed as batches used non-deterministic values (timestamps) in their ledger entry key, which made it impossible to generate the footprint for a `deposit`. This update fixes this issue and aims to eliminate the ever-growing vector of user batches as a data entry.