### PR TITLE
on-chain vm trap fix + updated auth

### DIFF
--- a/flash-loan-vault/src/contract.rs
+++ b/flash-loan-vault/src/contract.rs
@@ -15,15 +15,15 @@ pub trait VaultContractTrait {
         flash_loan_bytes: BytesN<32>,
     );
 
-    fn deposit(e: Env, from: Address, amount: i128) -> i128;
+    fn deposit(e: Env, admin: Address, from: Address, amount: i128) -> i128;
 
-    fn fee_withd(e: Env, to: Address, batch_ts: i128, shares: i128);
+    fn fee_withd(e: Env, admin: Address, to: Address, batch_ts: i128, shares: i128);
 
     fn get_shares(e: Env, id: Address, batch_ts: i128) -> Option<BatchObj>;
 
     fn batches(e: Env, id: Address) -> Vec<i128>;
 
-    fn withdraw(e: Env, to: Address) -> i128;
+    fn withdraw(e: Env, admin: Address, to: Address) -> i128;
 }
 
 pub struct VaultContract;
@@ -49,7 +49,12 @@ impl VaultContractTrait for VaultContract {
         put_token_id(&e, token_id);
     }
 
-    fn deposit(e: Env, from: Address, amount: i128) -> i128 {
+    fn deposit(e: Env, admin: Address, from: Address, amount: i128) -> i128 {
+        if read_admin(&e) != admin {
+            panic!("not the admin")
+        }
+        admin.require_auth();
+
         transfer_in_vault(&e, &from, &amount);
 
         let contract_id = get_token_id(&e);
@@ -82,7 +87,13 @@ impl VaultContractTrait for VaultContract {
         get_user_batches(&e, id)
     }
 
-    fn fee_withd(e: Env, to: Address, batch_n: i128, shares: i128) {
+    fn fee_withd(e: Env, admin: Address, to: Address, batch_n: i128, shares: i128) {
+        if read_admin(&e) != admin {
+            panic!("not the admin")
+        }
+
+        admin.require_auth();
+
         let tot_supply = get_tot_supply(&e);
         let tot_bal = get_token_balance(&e);
         let batch: BatchObj = e
@@ -117,7 +128,13 @@ impl VaultContractTrait for VaultContract {
         }
     }
 
-    fn withdraw(e: Env, to: Address) -> i128 {
+    fn withdraw(e: Env, admin: Address, to: Address) -> i128 {
+        if read_admin(&e) != admin {
+            panic!("not the admin")
+        }
+
+        admin.require_auth();
+
         let batches = get_user_batches(&e, to.clone());
         log!(&e, "batches {}", batches);
 

--- a/flash-loan-vault/src/storage.rs
+++ b/flash-loan-vault/src/storage.rs
@@ -73,7 +73,7 @@ pub fn has_administrator(e: &Env) -> bool {
     e.storage().has(&key)
 }
 
-pub fn _read_administrator(e: &Env) -> Address {
+pub fn read_admin(e: &Env) -> Address {
     let key = DataKey::Admin;
     e.storage().get_unchecked(&key).unwrap()
 }

--- a/flash-loan-vault/tests/test.rs
+++ b/flash-loan-vault/tests/test.rs
@@ -49,28 +49,28 @@ fn test() {
     usdc_token.mint(&admin1, &user1, &1000);
     usdc_token.mint(&admin1, &user2, &1000);
 
-    vault_client.deposit(&user1, &500);
+    vault_client.deposit(&user1, &user1, &500);
 
     assert_eq!(usdc_token.balance(&user1), 500);
 
-    vault_client.fee_withd(&user1, &0, &500);
+    vault_client.fee_withd(&user1, &user1, &0, &500);
 
     assert_eq!(usdc_token.balance(&user1), 500);
 
     let _batch = vault_client.get_shares(&user1, &0);
 
-    vault_client.deposit(&user2, &1000);
+    vault_client.deposit(&user1, &user2, &1000);
 
     assert_eq!(usdc_token.balance(&user2), 0);
 
     let _batch = vault_client.get_shares(&user2, &0);
 
-    vault_client.fee_withd(&user2, &0, &1000);
+    vault_client.fee_withd(&user1, &user2, &0, &1000);
 
     // fees arrive
     usdc_token.mint(&admin1, &vault_id, &(100));
 
-    vault_client.fee_withd(&user2, &1, &500);
+    vault_client.fee_withd(&user1, &user2, &1, &500);
 
     let _batch = vault_client.get_shares(&user2, &1);
 

--- a/proxy/src/storage.rs
+++ b/proxy/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, BytesN, Env};
+use soroban_sdk::{symbol, vec, Address, BytesN, Env, IntoVal, Symbol};
 
 use crate::{
     flash_loan,
@@ -61,18 +61,24 @@ pub fn get_flash_loan(env: &Env, token_contract_id: BytesN<32>) -> Result<BytesN
         Err(Error::FlashLoanDoesntExist)
     }
 }
-
+/*
 pub fn vault_deposit(
     env: &Env,
     provider: Address,
     token_contract_id: BytesN<32>,
     amount: i128,
 ) -> Result<(), Error> {
-    let vault_client = vault::Client::new(env, &get_vault(env, token_contract_id)?);
-    vault_client.deposit(&provider, &amount);
+    //    let vault_client = vault::Client::new(env, &get_vault(env, token_contract_id)?);
+
+    env.invoke_contract::<Symbol>(
+        &get_vault(env, token_contract_id)?,
+        &symbol!("deposits"),
+        vec![&env, provider.into_val(env), amount.into_val(env)],
+    );
+    //    vault_client.deposit(&provider, &amount);
 
     Ok(())
-}
+}*/
 
 pub fn vault_withdraw_fees(
     env: &Env,

--- a/proxy/src/storage.rs
+++ b/proxy/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{symbol, vec, Address, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{Address, BytesN, Env};
 
 use crate::{
     flash_loan,
@@ -61,24 +61,6 @@ pub fn get_flash_loan(env: &Env, token_contract_id: BytesN<32>) -> Result<BytesN
         Err(Error::FlashLoanDoesntExist)
     }
 }
-/*
-pub fn vault_deposit(
-    env: &Env,
-    provider: Address,
-    token_contract_id: BytesN<32>,
-    amount: i128,
-) -> Result<(), Error> {
-    //    let vault_client = vault::Client::new(env, &get_vault(env, token_contract_id)?);
-
-    env.invoke_contract::<Symbol>(
-        &get_vault(env, token_contract_id)?,
-        &symbol!("deposits"),
-        vec![&env, provider.into_val(env), amount.into_val(env)],
-    );
-    //    vault_client.deposit(&provider, &amount);
-
-    Ok(())
-}*/
 
 pub fn vault_withdraw_fees(
     env: &Env,
@@ -88,7 +70,12 @@ pub fn vault_withdraw_fees(
     shares: i128,
 ) -> Result<(), Error> {
     let vault_client = vault::Client::new(env, &get_vault(env, token_contract_id)?);
-    vault_client.fee_withd(&provider, &batch_n, &shares);
+    vault_client.fee_withd(
+        &env.current_contract_address(),
+        &provider,
+        &batch_n,
+        &shares,
+    );
     Ok(())
 }
 

--- a/proxy/src/types.rs
+++ b/proxy/src/types.rs
@@ -8,7 +8,7 @@ pub enum DataKey {
     FlashLoan(BytesN<32>),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[contracterror]
 #[repr(u32)]
 pub enum Error {


### PR DESCRIPTION
As rust tests cannot fully account for the contract's behavior when run on-chain, we're updating some parts of the protocol to not trap during the tx simulation. Currently, we've had to update the following methods:
- deposit

Another update for this PR is a fix for the overall protocol's auth that lacked some checks after the auth next upgrade.